### PR TITLE
RF: Specify location to libgnurx via env vars not via sudo copy

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
+
+set -eu
+export PS4='> '
+set -x
 mkdir dist/
 cd libgnurx-2.5
 make
-sudo cp regex.h /usr/x86_64-w64-mingw32/include/
-sudo cp libregex.a /usr/x86_64-w64-mingw32/lib/
-sudo cp libgnurx.dll.a /usr/x86_64-w64-mingw32/lib/
+#sudo cp regex.h /usr/x86_64-w64-mingw32/include/
+#sudo cp libregex.a /usr/x86_64-w64-mingw32/lib/
+#sudo cp libgnurx.dll.a /usr/x86_64-w64-mingw32/lib/
+export LDFLAGS="-L$PWD"
+export CFLAGS="-I$PWD"
 cp COPYING.LIB ../dist/COPYING.libgnurx
 cp libgnurx-0.dll ../dist/
 cd ../file/

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,8 @@ make -j4
 cp magic/magic.mgc ../dist/
 make clean
 ./configure --disable-silent-rules --enable-fsect-man5 --host=x86_64-w64-mingw32
-make -j4
+# profile FILE_COMPILE since otherwise it would try to use "file.exe" even when cross-compiling
+make -j4 FILE_COMPILE=file
 cp src/.libs/libmagic-1.dll ../dist/
 cp src/.libs/file.exe ../dist/
 cp COPYING ../dist/COPYING.file


### PR DESCRIPTION
The motivation: build should not modify system wide installation of the libraries, as it does now via `sudo cp` calls on headers and build library for libgnurx.  I have tried to workaround via exporting LDFLAGS and CFLAGS (also added `set -eu` for early termination if any step fails and `set -x` for visualizing what actual command was ran):

This one I guess might be a "dead end" or just needs more tune up since for me the build failed with
```shell
$> git clean -dfx && PATH=/usr/lib/ccache:$PATH ./build.sh
...
> make -j4
make  all-recursive
make[1]: Entering directory '/home/yoh/proj/misc/file-windows/file'
Making all in src
make[2]: Entering directory '/home/yoh/proj/misc/file-windows/file/src'
sed -e "s/X.YY/$(echo 5.29 | tr -d .)/" < ../src/magic.h.in > magic.h
make  all-am
...
In file included from readcdf.c:39:
cdf.h:336:17: note: expected ‘const time_t *’ {aka ‘const long long int *’} but argument is of type ‘long int *’
  336 | char *cdf_ctime(const time_t *, char *);
      |                 ^~~~~~~~~~~~~~
/bin/bash ../libtool  --tag=CC   --mode=link x86_64-w64-mingw32-gcc -fvisibility=hidden -Wall -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith        -Wmissing-declarations -Wredundant-decls -Wnested-externs        -Wsign-compare -Wreturn-type -Wswitch -Wshadow        -Wcast-qual -Wwrite-strings -Wextra -Wunused-parameter -Wformat=2 -I/home/yoh/proj/misc/file-windows/libgnurx-2.5 -no-undefined -version-info 1:0:0 -L/home/yoh/proj/misc/file-windows/libgnurx-2.5 -o libmagic.la -rpath /usr/local/lib magic.lo apprentice.lo softmagic.lo ascmagic.lo encoding.lo compress.lo is_tar.lo readelf.lo print.lo fsmagic.lo funcs.lo apptype.lo der.lo cdf.lo cdf_time.lo readcdf.lo strlcpy.lo strlcat.lo getline.lo ctime_r.lo asctime_r.lo localtime_r.lo gmtime_r.lo pread.lo strcasestr.lo fmtcheck.lo dprintf.lo -lgnurx -lshlwapi -lgnurx 
libtool: link: x86_64-w64-mingw32-gcc -shared  .libs/magic.o .libs/apprentice.o .libs/softmagic.o .libs/ascmagic.o .libs/encoding.o .libs/compress.o .libs/is_tar.o .libs/readelf.o .libs/print.o .libs/fsmagic.o .libs/funcs.o .libs/apptype.o .libs/der.o .libs/cdf.o .libs/cdf_time.o .libs/readcdf.o .libs/strlcpy.o .libs/strlcat.o .libs/getline.o .libs/ctime_r.o .libs/asctime_r.o .libs/localtime_r.o .libs/gmtime_r.o .libs/pread.o .libs/strcasestr.o .libs/fmtcheck.o .libs/dprintf.o   -L/home/yoh/proj/misc/file-windows/libgnurx-2.5 -lshlwapi -lgnurx    -o .libs/libmagic-1.dll -Wl,--enable-auto-image-base -Xlinker --out-implib -Xlinker .libs/libmagic.dll.a
libtool: link: ( cd ".libs" && rm -f "libmagic.la" && ln -s "../libmagic.la" "libmagic.la" )
/bin/bash ../libtool  --tag=CC   --mode=link x86_64-w64-mingw32-gcc -fvisibility=hidden -Wall -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith        -Wmissing-declarations -Wredundant-decls -Wnested-externs        -Wsign-compare -Wreturn-type -Wswitch -Wshadow        -Wcast-qual -Wwrite-strings -Wextra -Wunused-parameter -Wformat=2 -I/home/yoh/proj/misc/file-windows/libgnurx-2.5  -L/home/yoh/proj/misc/file-windows/libgnurx-2.5 -o file.exe file.o libmagic.la -lgnurx 
libtool: link: x86_64-w64-mingw32-gcc -fvisibility=hidden -Wall -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith -Wmissing-declarations -Wredundant-decls -Wnested-externs -Wsign-compare -Wreturn-type -Wswitch -Wshadow -Wcast-qual -Wwrite-strings -Wextra -Wunused-parameter -Wformat=2 -I/home/yoh/proj/misc/file-windows/libgnurx-2.5 -o .libs/file.exe file.o  -L/home/yoh/proj/misc/file-windows/libgnurx-2.5 ./.libs/libmagic.dll.a -lshlwapi -lgnurx -L/usr/local/lib
libtool:   error: Could not determine the host path corresponding to
libtool:   error:   '/home/yoh/proj/misc/file-windows/file/src/.libs'
libtool:   error: Continuing, but uninstalled executables may not work.
libtool:   error: Could not determine the host path corresponding to
libtool:   error:   '/home/yoh/proj/misc/file-windows/libgnurx-2.5:/home/yoh/proj/misc/file-windows/file/src/.libs:/usr/local/lib:/usr/local/bin'
libtool:   error: Continuing, but uninstalled executables may not work.
make[3]: Leaving directory '/home/yoh/proj/misc/file-windows/file/src'
make[2]: Leaving directory '/home/yoh/proj/misc/file-windows/file/src'
Making all in magic
make[2]: Entering directory '/home/yoh/proj/misc/file-windows/file/magic'
/bin/bash: line 3: file.exe: command not found
Cannot use the installed version of file () to
cross-compile file 5.29
Please install file 5.29 locally first
make[2]: *** [Makefile:800: magic.mgc] Error 1
make[2]: Leaving directory '/home/yoh/proj/misc/file-windows/file/magic'
make[1]: *** [Makefile:401: all-recursive] Error 1
make[1]: Leaving directory '/home/yoh/proj/misc/file-windows/file'
make: *** [Makefile:333: all] Error 2
PATH=/usr/lib/ccache:$PATH ./build.sh  38.12s user 14.59s system 134% cpu 39.222 total

```